### PR TITLE
Feature/#72/Trim 정보 조회 API 구현 (#113)

### DIFF
--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/api/TrimController.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/api/TrimController.java
@@ -1,4 +1,22 @@
 package com.h2o.h2oServer.domain.trim.api;
 
+import com.h2o.h2oServer.domain.trim.application.TrimService;
+import com.h2o.h2oServer.domain.trim.dto.TrimDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
 public class TrimController {
+
+    private final TrimService trimService;
+
+    @GetMapping("vehicle/{vehicleId}/trim")
+    public List<TrimDto> getTrimInformation(@PathVariable Long vehicleId) {
+        return trimService.findTrimInformation(vehicleId);
+    }
 }

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/application/TrimService.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/application/TrimService.java
@@ -1,0 +1,34 @@
+package com.h2o.h2oServer.domain.trim.application;
+
+import com.h2o.h2oServer.domain.trim.dto.TrimDto;
+import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
+import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
+import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
+import com.h2o.h2oServer.domain.trim.mapper.TrimMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TrimService {
+    private final TrimMapper trimMapper;
+
+    public List<TrimDto> findTrimInformation(Long vehicleId) {
+        List<TrimEntity> trimEntities = trimMapper.findByCarId(vehicleId);
+
+        List<TrimDto> trimDtos = trimEntities.stream()
+                .map(trimEntity -> {
+                    Long trimId = trimEntity.getId();
+                    List<OptionStatisticsEntity> optionStatisticsEntities = trimMapper.findOptionStatistics(trimId);
+                    List<ImageEntity> imageEntities = trimMapper.findImages(trimId);
+
+                    return TrimDto.of(trimEntity, imageEntities, optionStatisticsEntities);
+                })
+                .collect(Collectors.toList());
+
+        return trimDtos;
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/ImageDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/ImageDto.java
@@ -1,0 +1,26 @@
+package com.h2o.h2oServer.domain.trim.dto;
+
+import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.awt.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ImageDto {
+    private List<String> images;
+
+    private ImageDto(List<String> images) {
+        this.images = images;
+    }
+
+    public static ImageDto of(List<ImageEntity> imageEntities) {
+        List<String> images = imageEntities.stream()
+                .map(ImageEntity::getImage)
+                .collect(Collectors.toList());
+
+        return new ImageDto(images);
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/OptionStatisticsDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/OptionStatisticsDto.java
@@ -1,0 +1,28 @@
+package com.h2o.h2oServer.domain.trim.dto;
+
+import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+public class OptionStatisticsDto {
+    private String dataLabel;
+    private Float frequency;
+
+    public static OptionStatisticsDto of(OptionStatisticsEntity entity) {
+        return OptionStatisticsDto.builder()
+                .dataLabel(entity.getName())
+                .frequency(entity.getUseCount())
+                .build();
+    }
+
+    public static List<OptionStatisticsDto> ListOf(List<OptionStatisticsEntity> entities) {
+        return entities.stream()
+                .map(OptionStatisticsDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/TrimDto.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/dto/TrimDto.java
@@ -1,0 +1,36 @@
+package com.h2o.h2oServer.domain.trim.dto;
+
+import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
+import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
+import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+public class TrimDto {
+    private Long id;
+    private String name;
+    private String description;
+    private Integer price;
+    private List<String> images;
+    private List<OptionStatisticsDto> options;
+
+    public static TrimDto of(TrimEntity trimEntity,
+                     List<ImageEntity> imageEntities,
+                     List<OptionStatisticsEntity> optionStatisticsEntities) {
+        return TrimDto.builder()
+                .id(trimEntity.getId())
+                .name(trimEntity.getName())
+                .description(trimEntity.getDescription())
+                .price(trimEntity.getPrice())
+                .images(imageEntities.stream()
+                        .map(ImageEntity::getImage)
+                        .collect(Collectors.toList()))
+                .options(OptionStatisticsDto.ListOf(optionStatisticsEntities))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/ImageEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/ImageEntity.java
@@ -1,0 +1,11 @@
+package com.h2o.h2oServer.domain.trim.entity;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ImageEntity {
+    private Long id;
+    private String image;
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/OptionStatisticsEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/OptionStatisticsEntity.java
@@ -1,0 +1,12 @@
+package com.h2o.h2oServer.domain.trim.entity;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OptionStatisticsEntity {
+    private Long id;
+    private String name;
+    private Float useCount;
+}

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/TrimEntity.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/entity/TrimEntity.java
@@ -1,4 +1,4 @@
-package com.h2o.h2oServer.domain.trim;
+package com.h2o.h2oServer.domain.trim.entity;
 
 import lombok.*;
 

--- a/backend/src/main/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapper.java
+++ b/backend/src/main/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapper.java
@@ -1,6 +1,8 @@
 package com.h2o.h2oServer.domain.trim.mapper;
 
-import com.h2o.h2oServer.domain.trim.TrimEntity;
+import com.h2o.h2oServer.domain.trim.entity.ImageEntity;
+import com.h2o.h2oServer.domain.trim.entity.OptionStatisticsEntity;
+import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -14,4 +16,8 @@ public interface TrimMapper {
     List<TrimEntity> findAll();
 
     List<String> showTables();
+
+    List<ImageEntity> findImages(Long id);
+
+    List<OptionStatisticsEntity> findOptionStatistics(Long id);
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
     init:
       mode: always
       schema-locations: classpath*:db/schema-ddl.sql
+      data-locations: classpath:db/trims-data.sql
 
 mybatis:
   type-aliases-package: com.h2o.h2oServer.domain

--- a/backend/src/main/resources/db/trims-data.sql
+++ b/backend/src/main/resources/db/trims-data.sql
@@ -1,0 +1,25 @@
+INSERT INTO car (name, price, category, image)
+VALUES
+    ('Car A', 20000, 'Sedan', 'car_a.jpg'),
+    ('Car B', 25000, 'SUV', 'car_b.jpg'),
+    ('Car C', 18000, 'Hatchback', 'car_c.jpg'),
+    ('Car D', 30000, 'SUV', 'car_d.jpg'),
+    ('Car E', 22000, 'Sedan', 'car_e.jpg'),
+    ('Car F', 26000, 'Crossover', 'car_f.jpg'),
+    ('Car G', 19000, 'Hatchback', 'car_g.jpg'),
+    ('Car H', 28000, 'SUV', 'car_h.jpg'),
+    ('Car I', 23000, 'Sedan', 'car_i.jpg'),
+    ('Car J', 21000, 'Crossover', 'car_j.jpg');
+
+INSERT INTO trims (car_id, name, description, price)
+VALUES
+    (1, 'Trim 1', 'Basic Trim', 1500),
+    (1, 'Trim 2', 'Advanced Trim', 2500),
+    (2, 'Trim 3', 'Standard Trim', 2000),
+    (2, 'Trim 4', 'Premium Trim', 3000),
+    (3, 'Trim 5', 'Basic Trim', 1200),
+    (3, 'Trim 6', 'Advanced Trim', 2200),
+    (4, 'Trim 7', 'Standard Trim', 2800),
+    (4, 'Trim 8', 'Premium Trim', 3800),
+    (5, 'Trim 9', 'Basic Trim', 1700),
+    (5, 'Trim 10', 'Advanced Trim', 2700);

--- a/backend/src/main/resources/static/mapper/trim/TrimMapper.xml
+++ b/backend/src/main/resources/static/mapper/trim/TrimMapper.xml
@@ -8,10 +8,27 @@
         where id = #{id}
     </select>
 
+    <!--쿼리 최적화 필요-->
+    <select id="findOptionStatistics" resultType="OptionStatisticsEntity">
+        select id, name, use_count
+        from options
+            join trims_options
+            on options.id = trims_options.option_id
+        where trim_id = #{id}
+        order by use_count desc
+        limit 3
+    </select>
+
     <select id="findByCarId" resultType="TrimEntity">
         select id, name, description, price
         from trims
         where car_id = #{id}
+    </select>
+
+    <select id="findImages" resultType="ImageEntity">
+        select id, image
+        from trims_image
+        where trim_id = #{id}
     </select>
 
     <select id="showTables" resultType="string">

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/application/TrimServiceTest.java
@@ -1,0 +1,57 @@
+package com.h2o.h2oServer.domain.trim.application;
+
+import com.h2o.h2oServer.domain.trim.dto.TrimDto;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Sql("classpath:db/trims-data.sql")
+class TrimServiceTest {
+
+    @Autowired
+    private TrimService trimService;
+    private SoftAssertions softly;
+
+    @BeforeEach
+    void setUp() {
+        softly = new SoftAssertions();
+    }
+    
+    @Test
+    @DisplayName("존재하는 vehicle에 대한 요청인 경우 Dto로 formatting해서 반환한다.")
+    void findTrimInformation() {
+        //given
+        Long vehicleId = 1L;
+
+        //when
+        List<TrimDto> actualTrimDtos = trimService.findTrimInformation(vehicleId);
+
+        //then
+        softly.assertThat(actualTrimDtos).as("null이 아니다.").isNotNull();
+        softly.assertThat(actualTrimDtos).as("TrimDto를 포함한다.").isNotEmpty();
+        softly.assertThat(actualTrimDtos.get(0).getImages()).as("Images를 포함한다.").isNotNull();
+        softly.assertThat(actualTrimDtos.get(0).getOptions()).as("Options를 포함한다.").isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 vehicle에 대한 요청인 경우 빈 Dto를 반한환다.")
+    void findTrimInformationNotExist() {
+        //given
+        Long vehicleId = Long.MAX_VALUE;
+
+        //when
+        List<TrimDto> actualTrimDtos = trimService.findTrimInformation(vehicleId);
+
+        //then
+        softly.assertThat(actualTrimDtos).as("null이 아니다.").isNotNull();
+        softly.assertThat(actualTrimDtos).as("TrimDto를 포함하지 않는다.").isEmpty();
+    }
+}

--- a/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
+++ b/backend/src/test/java/com/h2o/h2oServer/domain/trim/mapper/TrimMapperTest.java
@@ -1,6 +1,6 @@
 package com.h2o.h2oServer.domain.trim.mapper;
 
-import com.h2o.h2oServer.domain.trim.TrimEntity;
+import com.h2o.h2oServer.domain.trim.entity.TrimEntity;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.*;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Sql("classpath:db/trims-data.sql")
 class TrimMapperTest {
+
+    //todo : 예외 처리 테스트 추가
 
     @Autowired
     private TrimMapper trimMapper;


### PR DESCRIPTION
* feat: trim's option 통계 정보 관련 쿼리, 매퍼 구현

* feat: trim 이미지 관련 쿼리, 매퍼 구현

* feat: TrimMapper 메소드 쿼리 연결

* refactor: Entity 패키지 분리

* feat: Trim 정보 API 관련 DTO 구현

* test: Trim 정보 API 서비스 메소드 테스트 코드 구현

* feat: Trim 정보 API 서비스 메소드 구현

* test: 로컬 테스트 환경에 더미 데이터 DML 추가

* feat: trim 정보 반환 API 엔드포인트 구현

* chore: todo 주석 작성

# :eyes: What is this PR?

# :pencil: Changes

## :pushpin: Related issue(s)

## :camera: Attachment(optional)
